### PR TITLE
Fetch local news page

### DIFF
--- a/news/new_vision.py
+++ b/news/new_vision.py
@@ -14,11 +14,9 @@ class NewVision(News):
         # del paragraphs[0:2]
         # del paragraphs[-7:]
         cleaned_text = []
-        # for p in paragraphs:
-        #     p_text = p.get_text().strip()
-        #     cleaned_text.append(p_text)
-        p_text = paragraphs.strip()
-        cleaned_text.append(p_text)
+        for p in paragraphs:
+            p_text = p.get_text().strip()
+            cleaned_text.append(p_text)
         return " ".join(cleaned_text)
 
     def fetch_news(self):
@@ -30,27 +28,31 @@ class NewVision(News):
         soup1 = BeautifulSoup(coverpage, 'html5lib')
 
         # Pick out the divs that hold links to news articles
-        divs1 = soup1.find_all('div')
-        divs2 = divs1[2].find_all('div', id='wrapper-container')
-        article_links = divs2[0].find_all('a')
+        # divs1 = soup1.find_all('div')
+        # divs2 = divs1[2].find('div', id='wrapper-container')
+        # article_links = divs2.find_all('a')
+        article_links = []
+        divs = soup1.find_all('div', class_='list_discription')
+        for div in divs:
+            article_links.append(div.find('a')['href'])
 
         # Follow each link and fetch the article content
         all_articles = []
 
         for link in article_links:
-            if "/news" in link['href']:
-                article = requests.get(self.url + link['href'])
-                article_content = article.content
-                soup2 = BeautifulSoup(article_content, 'html5lib')
-                soup3 = soup2.find('div', class_='container_left')
-                if soup3:
-                    title = soup3.find('h1').get_text()
-                    print(title)
-                    slug = "-".join(title.split())
-                    soup4 = soup3.find('div', class_='article-content')
-                    paragraphs = soup4.get_text()
-                    cleaned_article = self.clean_article_text(paragraphs)
-                    all_articles.append({'slug': slug, 'text': cleaned_article})
-                    all_articles.append({'slug': slug, 'text': paragraphs})
+            article = requests.get(self.url + link)
+            article_content = article.content
+            soup2 = BeautifulSoup(article_content, 'html5lib')
+            soup3 = soup2.find('div', class_='container_left')
+            if soup3:
+                title = soup3.find('h1').get_text()
+                slug = "-".join(title.split())
+                soup4 = soup3.find('div', class_='article-content')
+                paragraphs = soup4.find_all('p')
+                cleaned_article = self.clean_article_text(paragraphs)
+                all_articles.append(
+                    {'slug': slug, 'text': cleaned_article}
+                )
+                all_articles.append({'slug': slug, 'text': paragraphs})
 
         return all_articles

--- a/news/new_vision.py
+++ b/news/new_vision.py
@@ -53,6 +53,5 @@ class NewVision(News):
                 all_articles.append(
                     {'slug': slug, 'text': cleaned_article}
                 )
-                all_articles.append({'slug': slug, 'text': paragraphs})
 
         return all_articles

--- a/news/new_vision.py
+++ b/news/new_vision.py
@@ -11,12 +11,14 @@ class NewVision(News):
         super().__init__(url, article_href)
 
     def clean_article_text(self, paragraphs):
-        del paragraphs[0:2]
-        del paragraphs[-7:]
+        # del paragraphs[0:2]
+        # del paragraphs[-7:]
         cleaned_text = []
-        for p in paragraphs:
-            p_text = p.get_text().strip()
-            cleaned_text.append(p_text)
+        # for p in paragraphs:
+        #     p_text = p.get_text().strip()
+        #     cleaned_text.append(p_text)
+        p_text = paragraphs.strip()
+        cleaned_text.append(p_text)
         return " ".join(cleaned_text)
 
     def fetch_news(self):
@@ -40,10 +42,15 @@ class NewVision(News):
                 article = requests.get(self.url + link['href'])
                 article_content = article.content
                 soup2 = BeautifulSoup(article_content, 'html5lib')
-                title = soup2.find('h1').get_text()
-                slug = "-".join(title.split())
-                paragraphs = soup2.find_all('p', recursive=True)
-                cleaned_article = self.clean_article_text(paragraphs)
-                all_articles.append({'slug': slug, 'text': cleaned_article})
+                soup3 = soup2.find('div', class_='container_left')
+                if soup3:
+                    title = soup3.find('h1').get_text()
+                    print(title)
+                    slug = "-".join(title.split())
+                    soup4 = soup3.find('div', class_='article-content')
+                    paragraphs = soup4.get_text()
+                    cleaned_article = self.clean_article_text(paragraphs)
+                    all_articles.append({'slug': slug, 'text': cleaned_article})
+                    all_articles.append({'slug': slug, 'text': paragraphs})
 
         return all_articles


### PR DESCRIPTION
This PR changes the implementation of the New Vision web page scraping. Instead of scraping only the topmost recent articles on the cover page, the scraper now goes to the `/local` page and gets the local news articles from there