### PR TITLE
Set up exception handling and logging for possible database errors

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -1,3 +1,4 @@
+import logging
 import pymongo
 from news import (
     NewVision, DailyMonitor, Observer
@@ -22,7 +23,17 @@ print(nv_news)
 print(dm_news)
 print(ob_news)
 
+# Set up logger in case of database insertion errors
+logging.basicConfig(filename='example.log', level=logging.ERROR)
+
 # Insert into MongoDB database
-news_col.insert_many(nv_news)
-news_col.insert_many(dm_news)
-news_col.insert_many(ob_news)
+try:
+    news_col.insert_many(nv_news)
+    news_col.insert_many(dm_news)
+    news_col.insert_many(ob_news)
+except pymongo.bulk.BulkWriteError as bwe:
+    for err in bwe.details['writeErrors']:
+        if int(err['code']) == 11000:
+            pass
+        else:
+            logging.error(err['errmsg'])


### PR DESCRIPTION
This PR sets up logging for database insertion errors. 

I have noticed that sometimes, a `bulk write` error occurs when trying to insert articles into the MongoDB database. 

Possible causes:
* Inserting a huge number of posts at once (in the case of The Observer newspaper, these can go up to 100)
* The uniqueness constraint I set on the database, in which a certain article title can only be inserted once. This constraint was set up because of the fact that the newspaper webpages sometimes have some trending articles linked more than once.

I am still researching the exact cause and possible solutions.